### PR TITLE
fix: missing strike name and image

### DIFF
--- a/materialdeck-pf2e.js
+++ b/materialdeck-pf2e.js
@@ -428,7 +428,8 @@ class system {
             }
             let actions = this.getActorData(token).actions?.filter(a=>a.type == 'strike');
             for (let a of actions) {
-                a.img = a.imageUrl;
+                a.img = a.imageUrl || a.item?.img;
+                a.name = a.label || a.item?.name;
                 a.data = {
                     sort: 1
                 };


### PR DESCRIPTION
I thought the strikes weren't working properly with PF2 hower it seems that the image and name are just not displayed when the action comes from a weapon item (which happen in the majority of cases).

I attempted to fix the code extracting the strike information so that:

- The image is taken from the action associated item (if any) if no image has been found on the action itself.
- The name of the action is taken from the action `label` attribute (since there is no `name` attribute) or from the item name if any and no label has been found on the action itself.

closes #3 

Hope this helps :)